### PR TITLE
Remove non-existent fields from campaign schema

### DIFF
--- a/tap_adwords/schemas/campaigns.json
+++ b/tap_adwords/schemas/campaigns.json
@@ -106,22 +106,6 @@
         "string"
       ]
     },
-    "conversionOptimizerEligibility": {
-      "inclusion": "available",
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": {
-        "eligible": {
-          "inclusion": "available",
-          "type": [
-            "null",
-            "integer"
-          ]
-        }
-      }
-    },
     "advertisingChannelType": {
       "inclusion": "available",
       "type": [
@@ -129,51 +113,12 @@
         "string"
       ]
     },
-    "networkSetting": {
-      "inclusion": "available",
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": {
-        "targetGoogleSearch": {
-          "inclusion": "available",
-          "type": [
-            "null",
-            "integer"
-          ]
-        }
-      }
-    },
     "baseCampaignId": {
       "inclusion": "available",
       "type": [
         "null",
         "integer"
       ]
-    },
-    "frequencyCap": {
-      "inclusion": "available",
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": {
-        "impressions": {
-          "inclusion": "available",
-          "type": [
-            "null",
-            "integer"
-          ]
-        },
-        "timeUnit": {
-          "inclusion": "available",
-          "type": [
-            "null",
-            "string"
-          ]
-        }
-      }
     },
     "labels": {
       "items": {


### PR DESCRIPTION
Getting the error

```
SelectorError.INVALID_FIELD_NAME @ serviceSelector; trigger:'ConversionOptimizerEligibility',
SelectorError.INVALID_FIELD_NAME @ serviceSelector; trigger:'FrequencyCap',
SelectorError.INVALID_FIELD_NAME @ serviceSelector; trigger:'Net
workSetting'
```

during campaign sync. Removing these fields fixes campaign syncing.