### PR TITLE
Adding shopping report

### DIFF
--- a/tap_adwords/__init__.py
+++ b/tap_adwords/__init__.py
@@ -100,7 +100,7 @@ VERIFIED_REPORTS = frozenset([
     #'SHARED_SET_CRITERIA_REPORT',                      -- does NOT allow for querying by date range
     #'SHARED_SET_REPORT',                               -- does NOT allow for querying by date range
     #'SHARED_SET_REPORT',
-    #'SHOPPING_PERFORMANCE_REPORT',
+    'SHOPPING_PERFORMANCE_REPORT',
     #'TOP_CONTENT_PERFORMANCE_REPORT',
     #'URL_PERFORMANCE_REPORT',
     #'USER_AD_DISTANCE_REPORT',


### PR DESCRIPTION
I've tested the shopping report extensively locally. It works for all dimensions/segments that my account has access to.

The only dimensions I haven't been able to test (because we don't utilize) are:
* CategoryL1-5
* CustomAttribute0-4
* ProductTypeL1-5
* ChannelExclusivity
* ProductCondition

Google shopping makes up more than half of Google's search revenue - so it's absence feels a bit inappropriate.

I have a catalog file built out if you'd like to test.