### PR TITLE
Lower the page size back to 1000

### DIFF
--- a/tap_adwords/__init__.py
+++ b/tap_adwords/__init__.py
@@ -30,7 +30,7 @@ import math
 LOGGER = singer.get_logger()
 SESSION = requests.Session()
 
-PAGE_SIZE = 10000
+PAGE_SIZE = 1000
 VERSION = 'v201802'
 
 REPORT_TYPE_MAPPINGS = {"Boolean":  {"type": ["null", "boolean"]},


### PR DESCRIPTION
We raised the page size without realizing how much memory Adwords responses would start using. This reduction to the previous value should resolve our memory issues.