### PR TITLE
Removing suds and updating to a tested and compatible zeep version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='tap-adwords',
           'singer-python==5.1.5',
           'requests==2.13.0',
           'googleads==13.0.0',
-          'suds-jurko==0.6'
+          'zeep==3.1.0', # googleads dependency, pinned to 3.1.0 (tested version)
       ],
       entry_points='''
           [console_scripts]

--- a/tap_adwords/__init__.py
+++ b/tap_adwords/__init__.py
@@ -368,21 +368,6 @@ def sync_report_for_day(stream_name, stream_schema, sdk_client, start, field_lis
         LOGGER.info("Done syncing %s records for the %s report for customer_id %s on %s",
                     counter.value, stream_name, customer_id, start)
 
-def suds_to_dict(obj):
-    if not hasattr(obj, '__keylist__'):
-        return obj
-    data = {}
-    fields = obj.__keylist__
-    for field in fields:
-        val = getattr(obj, field)
-        if isinstance(val, list):
-            data[field] = []
-            for item in val:
-                data[field].append(suds_to_dict(item))
-        else:
-            data[field] = suds_to_dict(val)
-    return data
-
 CAMPAIGNS_BLACK_LISTED_FIELDS = set(['networkSetting', 'conversionOptimizerEligibility',
                                      'frequencyCap'])
 AD_GROUPS_BLACK_LISTED_FIELDS = set(['biddingStrategyConfiguration'])
@@ -674,8 +659,7 @@ def sync_campaign_ids_endpoint(sdk_client,
                 with metrics.record_counter(stream) as counter:
                     time_extracted = utils.now()
 
-                    for entry in page['entries']:
-                        obj = suds_to_dict(entry)
+                    for obj in page['entries']:
                         obj['_sdc_customer_id'] = sdk_client.client_customer_id
                         with Transformer(singer.UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
                             bumble_bee.pre_hook = transform_pre_hook
@@ -731,8 +715,7 @@ def sync_generic_basic_endpoint(sdk_client, stream, stream_metadata):
             with metrics.record_counter(stream) as counter:
                 time_extracted = utils.now()
 
-                for entry in page['entries']:
-                    obj = suds_to_dict(entry)
+                for obj in page['entries']:
                     obj['_sdc_customer_id'] = sdk_client.client_customer_id
                     with Transformer(singer.UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
                         bumble_bee.pre_hook = transform_pre_hook


### PR DESCRIPTION
I noticed that the only reason we're including suds was as a transitive dependency call out for the googleads SDK. It wasn't actually being imported at all.

This explicitly references the version of zeep that has been tested with the code to serialize objects and the pinned version of the googleads SDK. Also, this PR removes the references to suds.