### PR TITLE
Fallback to UTC if no managed customers are available

### DIFF
--- a/tap_adwords/__init__.py
+++ b/tap_adwords/__init__.py
@@ -706,8 +706,16 @@ def get_and_cache_parent_account_tz_str(sdk_client):
                     # Should only ever have one result
                     'paging': {'startIndex': '0', 'numberResults': '1'}}
         results = get_page(sdk_client, selector, 'accounts', 0)
-        assert results['totalNumEntries'] == 1
-        parent_account_tz_cache[sdk_client.client_customer_id] = results['entries'][0]['dateTimeZone']
+        assert results['totalNumEntries'] <= 1
+        if results['totalNumEntries'] == 1:
+            parent_account_tz_cache[sdk_client.client_customer_id] = results['entries'][0]['dateTimeZone']
+        elif results['totalNumEntries'] == 0:
+            LOGGER.warning(("Google returned an empty managed customer "
+                            "result set for %s which should not happen "
+                            "based on our understanding of the API. "
+                            "Falling back (possibly erroneously) to UTC."),
+                           sdk_client.client_customer_id)
+            parent_account_tz_cache[sdk_client.client_customer_id] = 'UTC'
 
     return parent_account_tz_cache[sdk_client.client_customer_id]
 


### PR DESCRIPTION
Motivation
----------

https://stitchdata.atlassian.net/browse/SUP-292

For context, we [previously][4] fixed parsing of `startDate` and `endDate`
fields on `campaign`s to parse through the parent account's timezone into
UTC as `YYYYMMDD` date strings. This remains in accordance with our best
understanding of the nature of those two fields based on the [Campaign API
Docs][5].

[4]: https://github.com/timvisher/tap-adwords/commit/20a02fa04a5ad0a39fcd85b7a0d2b9e728902a54
[5]: https://developers.google.com/adwords/api/docs/reference/v201809/CampaignService.Campaign#startdate

This worked for most customers but for some it resulted in an error
because the request for their account resulted in an empty resultset.

Based on my understanding of the [API Docs][1] there should be no reason
why a [ManagedCustomer][2] shouldn't come back from the
[ManagedCustomerService][3] for a customer id that the client has access
to. Nevertheless we've seen multiple occasions where none come back.
Falling back to UTC seems like a reasonable default although it's almost
certainly wrong.

[1]: https://developers.google.com/adwords/api/docs/reference/v201809/ManagedCustomerService
[2]: https://developers.google.com/adwords/api/docs/reference/v201809/ManagedCustomerService.ManagedCustomer
[3]: https://developers.google.com/adwords/api/docs/reference/v201809/ManagedCustomerService#get
