### PR TITLE
Add urlCustomParameters to campaign and adgroup schema

### DIFF
--- a/tap_adwords/metadata/ad_groups.json
+++ b/tap_adwords/metadata/ad_groups.json
@@ -31,4 +31,5 @@
  {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "campaignName"]},
  {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "status"]},
  {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "baseAdGroupId"]},
- {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "adGroupType"]}]
+ {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "adGroupType"]},
+ {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "urlCustomParameters"]}]

--- a/tap_adwords/metadata/campaigns.json
+++ b/tap_adwords/metadata/campaigns.json
@@ -37,4 +37,6 @@
  {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "campaignTrialType"]},
  {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "status"]},
  {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "networkSetting"]},
- {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "networkSetting", "properties", "targetGoogleSearch"]}]
+ {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "networkSetting", "properties", "targetGoogleSearch"]},
+ {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", "urlCustomParameters"]}
+]

--- a/tap_adwords/schemas/ad_groups.json
+++ b/tap_adwords/schemas/ad_groups.json
@@ -216,6 +216,31 @@
           }
         }
       }
+    },
+    "urlCustomParameters": {
+      "type": ["null", "object"],
+      "properties": {
+        "parameters": {
+          "type": ["array", "null"],
+          "items": {
+            "type": ["object", "null"],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": ["string", "null"]
+              },
+              "isRemove": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "doReplace": {
+          "type": "boolean"
+        }
+      }
     }
   }
 }

--- a/tap_adwords/schemas/campaigns.json
+++ b/tap_adwords/schemas/campaigns.json
@@ -248,6 +248,31 @@
         "null",
         "string"
       ]
+    },
+    "urlCustomParameters": {
+      "type": ["null", "object"],
+      "properties": {
+        "parameters": {
+          "type": ["array", "null"],
+          "items": {
+            "type": ["object", "null"],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": ["string", "null"]
+              },
+              "isRemove": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "doReplace": {
+          "type": "boolean"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Tested with real data. It appears that these come back as an object that wraps a list of objects.

Documentation of the top-level object schema:
https://developers.google.com/adwords/api/docs/reference/v201809/CampaignService.CustomParameters