### PR TITLE
Add install for setuptools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
             export LC_ALL=C
             python3 -m venv /usr/local/share/virtualenvs/tap-adwords
             source /usr/local/share/virtualenvs/tap-adwords/bin/activate
+            pip install -U setuptools
             pip install .[dev]
       - run:
           name: 'Pylint'


### PR DESCRIPTION
# Description of change
Circle tests aren't running because this dependency on `setuptools` is not being installed.

# Manual QA steps
 - 
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
