### PR TITLE
Update pip after creating the virtualenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             export LC_ALL=C
             python3 -m venv /usr/local/share/virtualenvs/tap-adwords
             source /usr/local/share/virtualenvs/tap-adwords/bin/activate
-            pip install -U setuptools
+            pip install -U 'pip<19.2' setuptools
             pip install .[dev]
       - run:
           name: 'Pylint'


### PR DESCRIPTION
# Description of change
The integration tests haven't run in a while because the virtualenv can't finish its setup.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
