### PR TITLE
Fix broken schema discovery docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following is an example of the required configuration
 
 ### Create a properties file
 
-The properties file will indicate what streams and fields to replicate from the AdWords API. The Tap takes advantage of the Singer best practices for [schema discovery and property selection](https://github.com/singer-io/getting-started/blob/master/BEST_PRACTICES.md#schema-discovery-and-property-selection).
+The properties file will indicate what streams and fields to replicate from the AdWords API. The Tap takes advantage of the Singer best practices for [schema discovery and property selection](https://github.com/singer-io/getting-started/blob/master/docs/BEST_PRACTICES.md#schemas).
 
 ### [Optional] Create the initial state file
 


### PR DESCRIPTION
# Description of change

In the repository's README, the link to the best practices documentation for schema discovery is broken. This PR updates the link to reflect the analogous page in singer-io/getting-started

# Manual QA steps
 - Click the link. It shouldn't 404.
 
# Risks
 - None.
 
# Rollback steps
 - revert this branch
