### PR TITLE
use singer catalog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-adwords',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_adwords'],
       install_requires=[
-          'singer-python==5.1.5',
+          'singer-python==5.9.0',
           'requests==2.20.0',
           'googleads==17.0.0',
           'pytz==2018.4',


### PR DESCRIPTION
# Description of change
Currently only the use of the deprecated parameter `-p` or `--properties` is possible. The new parameter `--catalog` is not supported yet.

With this pull request, support for the parameter `--catalog` is added. In addition, handling of interrupted executions is added.

# Manual QA steps
 - I tested this with stream `accounts` and it worked out fine
 
# Risks
 - upgrade of singer-python from 5.1.5 to 5.9.0
 
# Rollback steps
 - revert this branch
