### PR TITLE
limit setuptools to 51.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             export LC_ALL=C
             python3 -m venv /usr/local/share/virtualenvs/tap-adwords
             source /usr/local/share/virtualenvs/tap-adwords/bin/activate
-            pip install -U 'pip<19.2' setuptools
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
       - run:
           name: 'Pylint'


### PR DESCRIPTION
# Description of change
Limit setuptools to below version 51.0.0 to prevent conflicts.

# Manual QA steps
 - None
 
# Risks
 - None, change to package version installed for tests build.
 
# Rollback steps
 - revert this branch
