### PR TITLE
add landing page report into source code

### DIFF
--- a/tap_adwords/__init__.py
+++ b/tap_adwords/__init__.py
@@ -98,6 +98,7 @@ VERIFIED_REPORTS = frozenset([
     #'KEYWORDLESS_CATEGORY_REPORT',
     'KEYWORDLESS_QUERY_REPORT',
     'KEYWORDS_PERFORMANCE_REPORT',
+    'LANDING_PAGE_REPORT'
     #'LABEL_REPORT',                                    -- does NOT allow for querying by date range,
     #'PAID_ORGANIC_QUERY_REPORT',
     #'PARENTAL_STATUS_PERFORMANCE_REPORT',


### PR DESCRIPTION
# Description of change
Added into the source code of tap-adwords the possibility to extract the LANDING_PAGE_REPORT into the list of the reports to extract.

